### PR TITLE
Updating aspire and related packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,10 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AspireVersion>8.0.1</AspireVersion>
-    <AspireOpenAIVersion>$(AspireVersion)-preview.8.24267.1</AspireOpenAIVersion>
-    <SemanticKernelVersion>1.13.0</SemanticKernelVersion>
+    <AspireVersion>8.1.0</AspireVersion>
+    <AspireOpenAIVersion>8.0.1-preview.8.24267.1</AspireOpenAIVersion>
+    <SemanticKernelVersion>1.16.1</SemanticKernelVersion>
+    <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="$(AspireOpenAIVersion)" />
@@ -19,18 +20,19 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="$(SemanticKernelVersion)" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="$(SemanticKernelVersion)" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Postgres" Version="$(SemanticKernelVersion)-alpha" />
     <PackageVersion Include="Microsoft.SemanticKernel.Plugins.Memory" Version="$(SemanticKernelVersion)-alpha" />
     <PackageVersion Include="MudBlazor" Version="6.19.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="westwind.aspnetcore.markdown" Version="3.17.0" />
     <PackageVersion Include="YoutubeExplode" Version="6.3.16" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="$(OpenTelemetryVersion)-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>
 </Project>

--- a/YouTubeGPT.Client/YouTubeGPT.Client.csproj
+++ b/YouTubeGPT.Client/YouTubeGPT.Client.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="westwind.aspnetcore.markdown" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" />
     
   </ItemGroup>
 

--- a/YouTubeGPT.Shared/YouTubeGPT.Shared.csproj
+++ b/YouTubeGPT.Shared/YouTubeGPT.Shared.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Aspire.Npgsql" />
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.SemanticKernel" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Postgres" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" />
   </ItemGroup>


### PR DESCRIPTION
Had to keep the Azure OpenAI component at 8.0.1 as 8.1 depends on Azure.AI.OpenAI v2, whereas the SK package is still on v1
