### PR TITLE
Adicionar ingestão de transcrições de vídeo

### DIFF
--- a/src/YouTubeGPT.AppHost/Program.cs
+++ b/src/YouTubeGPT.AppHost/Program.cs
@@ -57,4 +57,6 @@ builder.AddProject<Projects.YouTubeGPT_Client>("youtubegpt-client")
     .WithConfiguration("Azure:AI:ChatDeploymentName")
     .WithExternalHttpEndpoints();
 
+builder.Services.AddScoped<BuildVectorDatabaseOperationHandler>();
+
 builder.Build().Run();

--- a/src/YouTubeGPT.Client/Program.cs
+++ b/src/YouTubeGPT.Client/Program.cs
@@ -22,6 +22,8 @@ builder.Services.AddMudServices();
 
 builder.Services.AddMarkdown();
 
+builder.Services.AddScoped<BuildVectorDatabaseOperationHandler>();
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();

--- a/src/YouTubeGPT.Database/MetadataDbContext.cs
+++ b/src/YouTubeGPT.Database/MetadataDbContext.cs
@@ -5,4 +5,5 @@ namespace YouTubeGPT.Ingestion;
 public class MetadataDbContext(DbContextOptions<MetadataDbContext> options) : DbContext(options)
 {
     public DbSet<MemoryMetadata> Metadata { get; set; }
+    public DbSet<VideoMetadata> VideoTranscriptions { get; set; }
 }

--- a/src/YouTubeGPT.Database/Migrations/20240312055537_InitialCreate.cs
+++ b/src/YouTubeGPT.Database/Migrations/20240312055537_InitialCreate.cs
@@ -26,6 +26,26 @@ namespace YouTubeGPT.Ingestion.Migrations
                 {
                     table.PrimaryKey("PK_Metadata", x => x.Id);
                 });
+
+            migrationBuilder.CreateTable(
+                name: "VideoTranscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    Duration = table.Column<TimeSpan>(type: "interval", nullable: true),
+                    Author = table.Column<string>(type: "text", nullable: false),
+                    Url = table.Column<string>(type: "text", nullable: false),
+                    UploadDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Keywords = table.Column<string[]>(type: "text[]", nullable: false),
+                    Transcription = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VideoTranscriptions", x => x.Id);
+                });
         }
 
         /// <inheritdoc />
@@ -33,6 +53,9 @@ namespace YouTubeGPT.Ingestion.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Metadata");
+
+            migrationBuilder.DropTable(
+                name: "VideoTranscriptions");
         }
     }
 }

--- a/src/YouTubeGPT.Database/Models/VideoMetadata.cs
+++ b/src/YouTubeGPT.Database/Models/VideoMetadata.cs
@@ -10,4 +10,5 @@ public class VideoMetadata
     public string Url { get; set; } = null!;
     public DateTimeOffset UploadDate { get; set; }
     public IReadOnlyList<string> Keywords { get; set; } = [];
+    public string Transcription { get; set; } = null!;
 }

--- a/src/YouTubeGPT.Ingestion/Components/Pages/Home.razor.cs
+++ b/src/YouTubeGPT.Ingestion/Components/Pages/Home.razor.cs
@@ -35,7 +35,7 @@ public partial class Home
             {
                 progress = p;
                 StateHasChanged();
-            }), model.MaxVideos);
+            }), model.MaxVideos, TimeSpan.FromMinutes(model.MinDuration));
             Snackbar.Add("Index built successfully", Severity.Success);
         }
         catch (Exception ex)


### PR DESCRIPTION
Adicione funcionalidade para ingerir transcrições de vídeo no aplicativo.

* **Em `BuildVectorDatabaseOperationHandler.cs`**:
- Descomente o código para baixar e salvar transcrições de vídeo.
- Adicione uma chamada para o método `SaveVideoTranscription` no método `Handle`.
- Implemente o método `SaveVideoTranscription` para salvar transcrições de vídeo na memória.

* **Em `Home.razor.cs`**:
- Atualize o método `BuildIndexAsync` para manipular transcrições de vídeo.

* **Em `MetadataDbContext.cs`**:
- Adicione uma propriedade `DbSet` para transcrições de vídeo.

* **Em `20240312055537_InitialCreate.cs`**:
- Atualize a migração para incluir um esquema para armazenar transcrições de vídeo.

* **Em `VideoMetadata.cs`**:
- Adicione uma propriedade para armazenar transcrições de vídeo.

* **Em `Program.cs` (AppHost e Client)**:
- Configure serviços para lidar com transcrições de vídeo.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Azure-Samples/YouTubeGPT?shareId=acd65c25-4da2-45fb-97f7-3eeb41c5910a).